### PR TITLE
Update install_monitoring.sh

### DIFF
--- a/install_monitoring.sh
+++ b/install_monitoring.sh
@@ -32,6 +32,7 @@ then
     echo -e "\e[1m\e[32m3.1 Installing Docker... \e[0m" && sleep 1
     sudo apt-get install ca-certificates curl gnupg lsb-release wget -y
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+    sudo chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
     sudo apt-get update
     sudo apt-get install docker-ce docker-ce-cli containerd.io -y


### PR DESCRIPTION
There have been permission issues while using the script. Changing the permissions of docker-archive-keyring.gpg fixes this.